### PR TITLE
Add mythological relics to treasure selection logic

### DIFF
--- a/bathala/src/data/relics/index.ts
+++ b/bathala/src/data/relics/index.ts
@@ -6,6 +6,7 @@ export {
   bossRelics as act1BossRelics,
   treasureRelics as act1TreasureRelics,
   shopRelics as act1ShopRelics,
+  mythologicalRelics as act1MythologicalRelics,
   allAct1Relics
 } from './Act1Relics';
 


### PR DESCRIPTION
Integrates mythological relics into the Act 1 treasure selection pool and updates the selection logic to use weighted randomization across common, elite, treasure, and mythological relics, excluding shop and boss relics. Also adds support for displaying relic sprites if available, with fallback to emoji, and refactors relic selection to ensure uniqueness and proper weighting.