### PR TITLE
feat: Expand enemy integration across chapters in Overworld and Node Generation

### DIFF
--- a/bathala/src/game/scenes/Overworld_TooltipManager.ts
+++ b/bathala/src/game/scenes/Overworld_TooltipManager.ts
@@ -12,6 +12,30 @@ import {
   TAWONG_LIPOD,
   MANGNANGAWAY
 } from '../../data/enemies/Act1Enemies';
+import {
+  SIRENA_ILLUSIONIST,
+  SIYOKOY_RAIDER,
+  SANTELMO_FLICKER,
+  BERBEROKA_LURKER,
+  MAGINDARA_SWARM,
+  KATAW,
+  BERBALANG,
+  SUNKEN_BANGKILAN,
+  APOY_TUBIG_FURY,
+  BAKUNAWA
+} from '../../data/enemies/Act2Enemies';
+import {
+  TIGMAMANUKAN_WATCHER,
+  DIWATA_SENTINEL,
+  SARIMANOK_KEEPER,
+  BULALAKAW_FLAMEWINGS,
+  MINOKAWA_HARBINGER,
+  ALAN,
+  EKEK,
+  RIBUNG_LINTI_DUO,
+  APOLAKI_GODLING,
+  FALSE_BATHALA
+} from '../../data/enemies/Act3Enemies';
 import { 
   TIKBALANG_SCOUT_LORE,
   BALETE_WRAITH_LORE,
@@ -498,8 +522,9 @@ export class Overworld_TooltipManager {
       return null;
     }
 
-    // Manually list all Act 1 enemies
+    // All enemies from all chapters
     const allEnemies = [
+      // Act 1
       TIKBALANG_SCOUT,
       BALETE_WRAITH,
       SIGBIN_CHARGER,
@@ -509,7 +534,29 @@ export class Overworld_TooltipManager {
       BUNGISNGIS,
       KAPRE_SHADE,
       TAWONG_LIPOD,
-      MANGNANGAWAY
+      MANGNANGAWAY,
+      // Act 2
+      SIRENA_ILLUSIONIST,
+      SIYOKOY_RAIDER,
+      SANTELMO_FLICKER,
+      BERBEROKA_LURKER,
+      MAGINDARA_SWARM,
+      KATAW,
+      BERBALANG,
+      SUNKEN_BANGKILAN,
+      APOY_TUBIG_FURY,
+      BAKUNAWA,
+      // Act 3
+      TIGMAMANUKAN_WATCHER,
+      DIWATA_SENTINEL,
+      SARIMANOK_KEEPER,
+      BULALAKAW_FLAMEWINGS,
+      MINOKAWA_HARBINGER,
+      ALAN,
+      EKEK,
+      RIBUNG_LINTI_DUO,
+      APOLAKI_GODLING,
+      FALSE_BATHALA
     ];
     const enemy = allEnemies.find(e => e.name === enemyId);
 
@@ -517,6 +564,7 @@ export class Overworld_TooltipManager {
 
     // Map enemy names to their detailed information from GDD
     const enemyDetailsMap: { [key: string]: { abilities: string, origin: string, corruption: string } } = {
+      // Act 1 enemies
       "Tikbalang Scout": {
         abilities: "Confuses Targeting • Applies Weak",
         origin: "Tagalog mountain trickster with backward hooves",
@@ -566,6 +614,108 @@ export class Overworld_TooltipManager {
         abilities: "Mimics Elements • Curses Cards • Hex of Reversal",
         origin: "Tagalog sorcerer with skull necklace",
         corruption: "Powerful witch casting evil hexes, commanding fates to reverse at their twisted will."
+      },
+      // Act 2 enemies
+      "Sirena Illusionist": {
+        abilities: "Heals • Stuns • Enchanting Magic",
+        origin: "Enchanting mermaids who use illusions and healing magic",
+        corruption: "Their songs once guided sailors safely; now they lure them to the depths."
+      },
+      "Siyokoy Raider": {
+        abilities: "Defends • Double Attack Pattern",
+        origin: "Aggressive male sea creatures, warriors of the deep",
+        corruption: "Guardians of submerged villages turned violent by the false god's whispers."
+      },
+      "Santelmo Flicker": {
+        abilities: "Fast Attacks • Flame Defense",
+        origin: "Fire spirits appearing as floating flames near water",
+        corruption: "Once guides for lost sailors, now leading them astray into darkness."
+      },
+      "Berberoka Lurker": {
+        abilities: "Weakens • Attack • Defense Pattern",
+        origin: "Water creature that swallows people whole",
+        corruption: "The river's hunger given form, consuming all who enter its domain."
+      },
+      "Magindara Swarm": {
+        abilities: "Swarm Attacks • Healing Songs",
+        origin: "Beautiful mermaids with enchanting voices",
+        corruption: "Their blessing songs twisted into drowning dirges."
+      },
+      "Kataw": {
+        abilities: "Heals • Strengthens • Guardian Pattern",
+        origin: "Half-human half-fish sea guardians",
+        corruption: "Ocean guardians defending corrupted waters against all intruders."
+      },
+      "Berbalang": {
+        abilities: "Weakens • Split Body Attack",
+        origin: "Vampire-like creature that can separate its body",
+        corruption: "Night hunters whose split forms stalk prey from multiple directions."
+      },
+      "Sunken Bangkilan": {
+        abilities: "Weakens • Heals • Strengthens • Heavy Attacks",
+        origin: "Cursed spirits from sunken villages",
+        corruption: "The vengeful dead of drowned settlements, seeking to add more to their numbers."
+      },
+      "Apoy-Tubig Fury": {
+        abilities: "Burns • Heals • Chaotic Elemental Attacks",
+        origin: "Elemental fusion of opposing fire and water forces",
+        corruption: "Elements that should never meet, raging with destructive chaos."
+      },
+      "Bakunawa": {
+        abilities: "Weakens • Strengthens • Poison • Moon Devourer",
+        origin: "Great serpent that devours the moon and causes eclipses",
+        corruption: "Promised eternal darkness by the false god in exchange for guarding the depths."
+      },
+      // Act 3 enemies
+      "Tigmamanukan Watcher": {
+        abilities: "Strengthens • Double Attack Pattern",
+        origin: "Celestial bird living at the world's edge",
+        corruption: "Watchers at creation's boundary, now casting down all who dare ascend."
+      },
+      "Diwata Sentinel": {
+        abilities: "Defensive Pattern • Nature Magic",
+        origin: "Divine nature spirits and guardians of sacred places",
+        corruption: "Sacred grove guardians corrupted to serve the false god's citadel."
+      },
+      "Sarimanok Keeper": {
+        abilities: "Weakens • Strengthens • Fortune Magic",
+        origin: "Legendary bird of good fortune",
+        corruption: "Blessings twisted into curses by the false god's corruption."
+      },
+      "Bulalakaw Flamewings": {
+        abilities: "Burns • Attack • Meteor Fire",
+        origin: "Meteor/shooting star spirits",
+        corruption: "Falling stars burning with celestial fire, reducing foes to ash."
+      },
+      "Minokawa Harbinger": {
+        abilities: "Eclipse • Moon Swallowing",
+        origin: "Giant bird that causes eclipses by swallowing the moon",
+        corruption: "Commanded by the false god to devour all light and hope."
+      },
+      "Alan": {
+        abilities: "Wing Attacks • Forest Magic",
+        origin: "Winged humanoid spirits from peaceful forests",
+        corruption: "Once peaceful forest dwellers, now striking down intruders from corrupted skies."
+      },
+      "Ekek": {
+        abilities: "Night Hunting • Blood Attacks",
+        origin: "Bird-like creature that hunts at night",
+        corruption: "Night hunters feeding the darkness with the blood of challengers."
+      },
+      "Ribung Linti Duo": {
+        abilities: "Lightning • Thunder • Synchronized Attacks",
+        origin: "Twin spirits of lightning and thunder",
+        corruption: "Storm twins whose synchronized strikes cannot be dodged."
+      },
+      "Apolaki Godling": {
+        abilities: "Sun Wrath • Divine Fire • War Magic",
+        origin: "Fragment of Apolaki, god of sun and war",
+        corruption: "Divine essence corrupted by the false Bathala, burning with twisted power."
+      },
+      "False Bathala": {
+        abilities: "Stuns • Weakens • Strengthens • Divine Attacks • Poison",
+        origin: "Impostor claiming the throne of the supreme deity",
+        corruption: "The usurper who took Bathala's throne, wielding stolen divine power."
       }
     };
 
@@ -585,13 +735,23 @@ export class Overworld_TooltipManager {
     
     const lore = loreMap[enemy.name];
 
+    // Generate sprite key from enemy name
     let spriteKeyBase = enemy.name.toLowerCase().split(" ")[0];
+    // Handle special cases for multi-word names
     if (spriteKeyBase === "tawong") {
         spriteKeyBase = "tawonglipod";
     }
-    // Additional check in case the enemy name is stored differently
     if (enemy.name.toLowerCase().includes("tawong")) {
         spriteKeyBase = "tawonglipod";
+    }
+    if (enemy.name.toLowerCase().includes("apoy-tubig")) {
+        spriteKeyBase = "apoytubig";
+    }
+    if (enemy.name.toLowerCase().includes("ribung linti")) {
+        spriteKeyBase = "ribunglinti";
+    }
+    if (enemy.name.toLowerCase().includes("false bathala")) {
+        spriteKeyBase = "falsebathala";
     }
     const spriteKey = spriteKeyBase + "_overworld";
 

--- a/bathala/src/utils/MazeGeneration/NodeGenerator.ts
+++ b/bathala/src/utils/MazeGeneration/NodeGenerator.ts
@@ -1,6 +1,10 @@
 import { MapNode, NodeType } from "../../core/types/MapTypes";
 import { SeededRandom } from "./types";
 import { ACT1_COMMON_ENEMIES, ACT1_ELITE_ENEMIES } from "../../data/enemies/Act1Enemies";
+import { ACT2_COMMON_ENEMIES, ACT2_ELITE_ENEMIES } from "../../data/enemies/Act2Enemies";
+import { ACT3_COMMON_ENEMIES, ACT3_ELITE_ENEMIES } from "../../data/enemies/Act3Enemies";
+import { GameState } from "../../core/managers/GameState";
+import { Chapter } from "../../core/types/CombatTypes";
 
 /*
   NodeGenerator
@@ -34,6 +38,24 @@ export class NodeGenerator {
   private static readonly MIN_OPEN_NEIGHBORS = 5;          // Minimum open neighbors for valid positions
   private static readonly BASE_NODE_COUNT = 3;             // Base number of nodes per chunk
   private static readonly MIN_NODE_DISTANCE_FACTOR = 4;    // Divisor for minimum distance between nodes
+
+  /**
+   * Get enemy arrays for the current chapter
+   */
+  private static getEnemyArraysForChapter(chapter: Chapter): {
+    common: typeof ACT1_COMMON_ENEMIES;
+    elite: typeof ACT1_ELITE_ENEMIES;
+  } {
+    switch (chapter) {
+      case 2:
+        return { common: ACT2_COMMON_ENEMIES, elite: ACT2_ELITE_ENEMIES };
+      case 3:
+        return { common: ACT3_COMMON_ENEMIES, elite: ACT3_ELITE_ENEMIES };
+      case 1:
+      default:
+        return { common: ACT1_COMMON_ENEMIES, elite: ACT1_ELITE_ENEMIES };
+    }
+  }
 
   /**
    * Generate nodes efficiently using spatial hashing
@@ -111,15 +133,19 @@ export class NodeGenerator {
       if (bestPosition) {
         const type = nodeTypes[Math.floor(rng.next() * nodeTypes.length)];
         
+        // Get current chapter for enemy selection
+        const currentChapter = GameState.getInstance().getCurrentChapter();
+        const enemyArrays = this.getEnemyArraysForChapter(currentChapter);
+        
         let enemyId: string | undefined = undefined;
         if (type === "combat") {
-          const enemyIndex = Math.floor(rng.next() * ACT1_COMMON_ENEMIES.length);
-          enemyId = ACT1_COMMON_ENEMIES[enemyIndex].name;
-          console.log(`Generated combat node: ${type}-${chunkX}-${chunkY}-${i}, enemyId: ${enemyId}, enemyIndex: ${enemyIndex}`);
+          const enemyIndex = Math.floor(rng.next() * enemyArrays.common.length);
+          enemyId = enemyArrays.common[enemyIndex].name;
+          console.log(`Generated combat node: ${type}-${chunkX}-${chunkY}-${i}, enemyId: ${enemyId}, chapter: ${currentChapter}`);
         } else if (type === "elite") {
-          const enemyIndex = Math.floor(rng.next() * ACT1_ELITE_ENEMIES.length);
-          enemyId = ACT1_ELITE_ENEMIES[enemyIndex].name;
-          console.log(`Generated elite node: ${type}-${chunkX}-${chunkY}-${i}, enemyId: ${enemyId}, enemyIndex: ${enemyIndex}`);
+          const enemyIndex = Math.floor(rng.next() * enemyArrays.elite.length);
+          enemyId = enemyArrays.elite[enemyIndex].name;
+          console.log(`Generated elite node: ${type}-${chunkX}-${chunkY}-${i}, enemyId: ${enemyId}, chapter: ${currentChapter}`);
         }
 
         nodes.push({


### PR DESCRIPTION
- Added Act 2 and Act 3 enemies to Overworld_TooltipManager for comprehensive enemy details.
- Updated NodeGenerator to dynamically select enemies based on the current chapter, enhancing combat node generation.